### PR TITLE
Don't restore brightness to more than default

### DIFF
--- a/src/Screen.m
+++ b/src/Screen.m
@@ -4,7 +4,7 @@
 
 @synthesize service;
 @synthesize key;
-
+float defaultBright;
 - (id)init {
     self = [super init];
     if (self != nil) {
@@ -30,10 +30,13 @@
 };
 
 - (void)restore {
-    [self changeBy:BRIGHTNESS_INCREMENT];
+    if(defaultBright > [self getBright]){
+        [self changeBy:BRIGHTNESS_INCREMENT];
+    }
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
+    defaultBright = [self getBright];
     [NSTimer scheduledTimerWithTimeInterval:1
                                      target:self
                                    selector:@selector(restore)


### PR DESCRIPTION
Right now the app restores to full brightness, but if someone prefers working with half brightness then it should restore to that instead. Sets the default as the brightness when the app is first run. 